### PR TITLE
20221114hasegawa 02

### DIFF
--- a/src/dbtest.php
+++ b/src/dbtest.php
@@ -7,7 +7,6 @@ createToken();
     <h1>データベース練習</h1>
     <p><a href="regist.php">登録</a></p>
     <p><a href="search.php">検索</a></p>
-
     <p>
     <form action="dummies_data_process.php" method="post">
 

--- a/src/dbtest.php
+++ b/src/dbtest.php
@@ -14,9 +14,9 @@ createToken();
         <input type="hidden" name="token" value="<?= hsc($_SESSION['token']); ?>">
 
         <button type="submit" name="dummies_install" value="1">ダミーデータ500件挿入</button>
-        
+
         <button type="submit" name="dummies_install" value="0">挿入したダミーデータを削除</button>
-        
+
     </form>
     </p>
 </main>

--- a/src/dbtest.php
+++ b/src/dbtest.php
@@ -7,6 +7,7 @@ createToken();
     <h1>データベース練習</h1>
     <p><a href="regist.php">登録</a></p>
     <p><a href="search.php">検索</a></p>
+
     <p>
     <form action="dummies_data_process.php" method="post">
 


### PR DESCRIPTION
わかりにくくしてしまって申し訳ありません。
dbtest.php>search.phpからDB内の検索ができるようになっていますが、検索結果が多数の時にページが20件ごとにページが分かれて表示されるようになっています。
searchresult.phpもコード全体フォーマッタをかけたり、ページ間送受信の形式をpostからgetにしたり、関数を導入してみたり(逆にコードが長くなってしまったので意味は希薄ですが)しています。